### PR TITLE
Handle Git wildmatch edge cases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,5 @@ group(:development) do
     gem 'ruby-debug'
   else
     gem 'pry', :require => 'pry'
-    gem 'pry-debugger'
   end
 end


### PR DESCRIPTION
This PR copies over some edge case handling from the Python pathspec library (https://github.com/cpburnz/python-path-specification/pull/8) that was introduced after this gem was ported.

The [original PR](https://github.com/cpburnz/python-path-specification/pull/8) goes into more detail but here's an overview of the edge cases:

> - `/` does NOT match all paths the repo
> - `/abs/path` matches: `abs/path/foo`
> - `spam` matches: `spam/`, `spam/foo`
> - `spam/two` does NOT match: `foo/spam/two`
> - `spam/**` does NOT match: `foo/spam/bar`
> - `left/**/right` does NOT match: `foo/left/bar/right`
> - `**/spam` does match: `foo/spam/`, `foo/spam/bar`
> - `foo-*-bar` does match: `foo-hello-bar/baz`
> - `~temp-*` does match: `~temp-foo/bar`
> - `*.py` does match: `bar.py/baz`