### PR TITLE
Fix travis build icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Follows .gitignore syntax defined on [gitscm](http://git-scm.com/docs/gitignore)
 
 .gitignore functionality ported from [Python pathspec](https://pypi.python.org/pypi/pathspec/0.2.2) by [@cpburnz](https://github.com/cpburnz/python-path-specification)
 
-[Travis Status](https://travis-ci.org/highb/pathspec-ruby) ![Travis CI Status](https://travis-ci.org/highb/pathspec-ruby.svg?branch=master)
+[![Build Status](https://travis-ci.org/highb/pathspec-ruby.svg?branch=master)](https://travis-ci.org/highb/pathspec-ruby)
 
 ## Build/Install from Rubygems
 ```shell


### PR DESCRIPTION
This commit fixes a typo in the Travis status icon.