### PR TITLE
Fix #from_filename not forwarding type arg

### DIFF
--- a/lib/pathspec.rb
+++ b/lib/pathspec.rb
@@ -75,7 +75,7 @@ class PathSpec
 
   # Generate specs from a filename, such as a .gitignore
   def self.from_filename(filename, type=:git)
-    self.from_lines(File.open(filename, 'r'))
+    self.from_lines(File.open(filename, 'r'), type)
   end
 
   def self.from_lines(lines, type=:git)

--- a/spec/unit/pathspec_spec.rb
+++ b/spec/unit/pathspec_spec.rb
@@ -307,6 +307,15 @@ REGEX
       expect(subject.match('anna')).to be false
       expect(subject.match('abba')).to be true
     end
+
+    context "#from_filename" do
+      it "forwards the type argument" do
+        expect(File).to receive(:open).and_return(anything)
+        expect(PathSpec).to receive(:from_lines).with(anything, :regex)
+
+        PathSpec.from_filename "/some/file", :regex
+      end
+    end
   end
 
   context "unsuppored spec type" do


### PR DESCRIPTION
Fixes `PathSpec.from_filename('/some/path', :regex)` not working.