### PR TITLE
Close opened file handle in #from_filename

### DIFF
--- a/lib/pathspec.rb
+++ b/lib/pathspec.rb
@@ -75,7 +75,7 @@ class PathSpec
 
   # Generate specs from a filename, such as a .gitignore
   def self.from_filename(filename, type=:git)
-    self.from_lines(File.open(filename, 'r'), type)
+    File.open(filename, 'r') { |io| self.from_lines(io, type) }
   end
 
   def self.from_lines(lines, type=:git)

--- a/spec/unit/pathspec_spec.rb
+++ b/spec/unit/pathspec_spec.rb
@@ -310,8 +310,10 @@ REGEX
 
     context "#from_filename" do
       it "forwards the type argument" do
-        expect(File).to receive(:open).and_return(anything)
-        expect(PathSpec).to receive(:from_lines).with(anything, :regex)
+        io = double
+
+        expect(File).to receive(:open).and_yield(io)
+        expect(PathSpec).to receive(:from_lines).with(io, :regex)
 
         PathSpec.from_filename "/some/file", :regex
       end


### PR DESCRIPTION
We can use the block form of `File.open` to accomplish that.