### PR TITLE
Fix regexp: Match A-Z, not A-z

### DIFF
--- a/lib/pathspec.rb
+++ b/lib/pathspec.rb
@@ -70,7 +70,7 @@ class PathSpec
   end
 
   def drive_letter_to_path(path)
-    path.gsub(/^([a-zA-z]):\//, '/\1/')
+    path.gsub(/^([a-zA-Z]):\//, '/\1/')
   end
 
   # Generate specs from a filename, such as a .gitignore


### PR DESCRIPTION
The regexp is otherwise overmatching, ASCII (and UTF) has many characters between Z and a which are currently also matched: ^ and _ for example.