### PR TITLE
Move constants under toplevel namespace

### DIFF
--- a/lib/pathspec/gitignorespec.rb
+++ b/lib/pathspec/gitignorespec.rb
@@ -2,169 +2,170 @@
 
 require 'pathspec/regexspec'
 
-class GitIgnoreSpec < RegexSpec
-  attr_reader :regex
+class PathSpec
+  class GitIgnoreSpec < RegexSpec
+    attr_reader :regex
 
-  def initialize(pattern)
-    pattern = pattern.strip unless pattern.nil?
+    def initialize(pattern)
+      pattern = pattern.strip unless pattern.nil?
 
-    # A pattern starting with a hash ('#') serves as a comment
-    # (neither includes nor excludes files). Escape the hash with a
-    # back-slash to match a literal hash (i.e., '\#').
-    if pattern.start_with?('#')
-      @regex = nil
-      @inclusive = nil
+      # A pattern starting with a hash ('#') serves as a comment
+      # (neither includes nor excludes files). Escape the hash with a
+      # back-slash to match a literal hash (i.e., '\#').
+      if pattern.start_with?('#')
+        @regex = nil
+        @inclusive = nil
 
-    # A blank pattern is a null-operation (neither includes nor
-    # excludes files).
-    elsif pattern.empty?
-      @regex = nil
-      @inclusive = nil
+        # A blank pattern is a null-operation (neither includes nor
+        # excludes files).
+      elsif pattern.empty?
+        @regex = nil
+        @inclusive = nil
 
-    # Patterns containing three or more consecutive stars are invalid and
-    # will be ignored.
-    elsif pattern =~ /\*\*\*+/
-      @regex = nil
-      @inclusive = nil
+        # Patterns containing three or more consecutive stars are invalid and
+        # will be ignored.
+      elsif pattern =~ /\*\*\*+/
+        @regex = nil
+        @inclusive = nil
 
-    # EDGE CASE: According to git check-ignore (v2.4.1)), a single '/'
-    # does not match any file
-    elsif pattern == '/'
-      @regex = nil
-      @inclusive = nil
+        # EDGE CASE: According to git check-ignore (v2.4.1)), a single '/'
+        # does not match any file
+      elsif pattern == '/'
+        @regex = nil
+        @inclusive = nil
 
-    # We have a valid pattern!
-    else
-      # A pattern starting with an exclamation mark ('!') negates the
-      # pattern (exclude instead of include). Escape the exclamation
-      # mark with a back-slash to match a literal exclamation mark
-      # (i.e., '\!').
-      if pattern.start_with?('!')
-        @inclusive = false
-        # Remove leading exclamation mark.
-        pattern = pattern[1..-1]
+        # We have a valid pattern!
       else
-        @inclusive = true
-      end
-
-      # Remove leading back-slash escape for escaped hash ('#') or
-      # exclamation mark ('!').
-      if pattern.start_with?('\\')
-        pattern = pattern[1..-1]
-      end
-
-      # Split pattern into segments. -1 to allow trailing slashes.
-      pattern_segs = pattern.split('/', -1)
-
-      # Normalize pattern to make processing easier.
-
-      # A pattern beginning with a slash ('/') will only match paths
-      # directly on the root directory instead of any descendant
-      # paths. So, remove empty first segment to make pattern relative
-      # to root.
-      if pattern_segs[0].empty?
-        pattern_segs.shift
-      elsif pattern_segs.length == 1 ||
-        pattern_segs.length == 2 && pattern_segs[-1].empty?
-        # A pattern without a beginning slash ('/') will match any
-        # descendant path. This is equivilent to "**/{pattern}". So,
-        # prepend with double-asterisks to make pattern relative to
-        # root.
-        # EDGE CASE: This also holds for a single pattern with a
-        # trailing slash (e.g. dir/).
-        if pattern_segs[0] != '**'
-          pattern_segs.insert(0, '**')
+        # A pattern starting with an exclamation mark ('!') negates the
+        # pattern (exclude instead of include). Escape the exclamation
+        # mark with a back-slash to match a literal exclamation mark
+        # (i.e., '\!').
+        if pattern.start_with?('!')
+          @inclusive = false
+          # Remove leading exclamation mark.
+          pattern = pattern[1..-1]
+        else
+          @inclusive = true
         end
-      end
 
-      # A pattern ending with a slash ('/') will match all descendant
-      # paths of if it is a directory but not if it is a regular file.
-      # This is equivilent to "{pattern}/**". So, set last segment to
-      # double asterisks to include all descendants.
-      if pattern_segs[-1].empty? && pattern_segs.length > 1
-        pattern_segs[-1] = '**'
-      end
+        # Remove leading back-slash escape for escaped hash ('#') or
+        # exclamation mark ('!').
+        if pattern.start_with?('\\')
+          pattern = pattern[1..-1]
+        end
 
-      # Handle platforms with backslash separated paths
-      if File::SEPARATOR == '\\'
-        path_sep = '\\\\'
-      else
-        path_sep = '/'
-      end
+        # Split pattern into segments. -1 to allow trailing slashes.
+        pattern_segs = pattern.split('/', -1)
+
+        # Normalize pattern to make processing easier.
+
+        # A pattern beginning with a slash ('/') will only match paths
+        # directly on the root directory instead of any descendant
+        # paths. So, remove empty first segment to make pattern relative
+        # to root.
+        if pattern_segs[0].empty?
+          pattern_segs.shift
+        elsif pattern_segs.length == 1 ||
+          pattern_segs.length == 2 && pattern_segs[-1].empty?
+          # A pattern without a beginning slash ('/') will match any
+          # descendant path. This is equivilent to "**/{pattern}". So,
+          # prepend with double-asterisks to make pattern relative to
+          # root.
+          # EDGE CASE: This also holds for a single pattern with a
+          # trailing slash (e.g. dir/).
+          if pattern_segs[0] != '**'
+            pattern_segs.insert(0, '**')
+          end
+        end
+
+        # A pattern ending with a slash ('/') will match all descendant
+        # paths of if it is a directory but not if it is a regular file.
+        # This is equivilent to "{pattern}/**". So, set last segment to
+        # double asterisks to include all descendants.
+        if pattern_segs[-1].empty? && pattern_segs.length > 1
+          pattern_segs[-1] = '**'
+        end
+
+        # Handle platforms with backslash separated paths
+        if File::SEPARATOR == '\\'
+          path_sep = '\\\\'
+        else
+          path_sep = '/'
+        end
 
 
-      # Build regular expression from pattern.
-      regex = '^'
-      need_slash = false
-      regex_end = pattern_segs.size - 1
-      pattern_segs.each_index do |i|
-        seg = pattern_segs[i]
+        # Build regular expression from pattern.
+        regex = '^'
+        need_slash = false
+        regex_end = pattern_segs.size - 1
+        pattern_segs.each_index do |i|
+          seg = pattern_segs[i]
 
-        if seg == '**'
-          # A pattern consisting solely of double-asterisks ('**')
-          # will match every path.
-          if i == 0 && i == regex_end
-            regex.concat('.+')
+          if seg == '**'
+            # A pattern consisting solely of double-asterisks ('**')
+            # will match every path.
+            if i == 0 && i == regex_end
+              regex.concat('.+')
 
-          # A normalized pattern beginning with double-asterisks
-          # ('**') will match any leading path segments.
-          elsif i == 0
-            regex.concat("(?:.+#{path_sep})?")
-            need_slash = false
+              # A normalized pattern beginning with double-asterisks
+              # ('**') will match any leading path segments.
+            elsif i == 0
+              regex.concat("(?:.+#{path_sep})?")
+              need_slash = false
 
-          # A normalized pattern ending with double-asterisks ('**')
-          # will match any trailing path segments.
-          elsif i == regex_end
-            regex.concat("#{path_sep}.*")
+              # A normalized pattern ending with double-asterisks ('**')
+              # will match any trailing path segments.
+            elsif i == regex_end
+              regex.concat("#{path_sep}.*")
 
-          # A pattern with inner double-asterisks ('**') will match
-          # multiple (or zero) inner path segments.
+              # A pattern with inner double-asterisks ('**') will match
+              # multiple (or zero) inner path segments.
+            else
+              regex.concat("(?:#{path_sep}.+)?")
+              need_slash = true
+            end
+
+            # Match single path segment.
+          elsif seg == '*'
+            if need_slash
+              regex.concat(path_sep)
+            end
+
+            regex.concat("[^#{path_sep}]+")
+            need_slash = true
+
           else
-            regex.concat("(?:#{path_sep}.+)?")
+            # Match segment glob pattern.
+            if need_slash
+              regex.concat(path_sep)
+            end
+
+            regex.concat(translate_segment_glob(seg))
+
+            if i == regex_end && @inclusive
+              # A pattern ending without a slash ('/') will match a file
+              # or a directory (with paths underneath it).
+              # e.g. foo matches: foo, foo/bar, foo/bar/baz, etc.
+              # EDGE CASE: However, this does not hold for exclusion cases
+              # according to `git check-ignore` (v2.4.1).
+              regex.concat("(?:#{path_sep}.*)?")
+            end
+
             need_slash = true
           end
-
-        # Match single path segment.
-        elsif seg == '*'
-          if need_slash
-            regex.concat(path_sep)
-          end
-
-          regex.concat("[^#{path_sep}]+")
-          need_slash = true
-
-        else
-          # Match segment glob pattern.
-          if need_slash
-            regex.concat(path_sep)
-          end
-
-          regex.concat(translate_segment_glob(seg))
-
-          if i == regex_end && @inclusive
-            # A pattern ending without a slash ('/') will match a file
-            # or a directory (with paths underneath it).
-            # e.g. foo matches: foo, foo/bar, foo/bar/baz, etc.
-            # EDGE CASE: However, this does not hold for exclusion cases
-            # according to `git check-ignore` (v2.4.1).
-            regex.concat("(?:#{path_sep}.*)?")
-          end
-
-          need_slash = true
         end
+
+        regex.concat('$')
+        super(regex)
       end
-
-      regex.concat('$')
-      super(regex)
     end
-  end
 
-  def match(path)
-    super(path)
-  end
+    def match(path)
+      super(path)
+    end
 
-  def translate_segment_glob(pattern)
-    """
+    def translate_segment_glob(pattern)
+      """
     Translates the glob pattern to a regular expression. This is used in
     the constructor to translate a path segment glob pattern to its
     corresponding regular expression.
@@ -172,123 +173,124 @@ class GitIgnoreSpec < RegexSpec
     *pattern* (``str``) is the glob pattern.
 
     Returns the regular expression (``str``).
-    """
-    # NOTE: This is derived from `fnmatch.translate()` and is similar to
-    # the POSIX function `fnmatch()` with the `FNM_PATHNAME` flag set.
+      """
+      # NOTE: This is derived from `fnmatch.translate()` and is similar to
+      # the POSIX function `fnmatch()` with the `FNM_PATHNAME` flag set.
 
-    escape = false
-    regex = ''
-    i = 0
+      escape = false
+      regex = ''
+      i = 0
 
-    while i < pattern.size
-      # Get next character.
-      char = pattern[i].chr
-      i += 1
+      while i < pattern.size
+        # Get next character.
+        char = pattern[i].chr
+        i += 1
 
-      # Escape the character.
-      if escape
-        escape = false
-        regex += Regexp.escape(char)
+        # Escape the character.
+        if escape
+          escape = false
+          regex += Regexp.escape(char)
 
-      # Escape character, escape next character.
-      elsif char == '\\'
-        escape = true
+          # Escape character, escape next character.
+        elsif char == '\\'
+          escape = true
 
-      # Multi-character wildcard. Match any string (except slashes),
-      # including an empty string.
-      elsif char == '*'
-        regex += '[^/]*'
+          # Multi-character wildcard. Match any string (except slashes),
+          # including an empty string.
+        elsif char == '*'
+          regex += '[^/]*'
 
-      # Single-character wildcard. Match any single character (except
-      # a slash).
-      elsif char == '?'
-        regex += '[^/]'
+          # Single-character wildcard. Match any single character (except
+          # a slash).
+        elsif char == '?'
+          regex += '[^/]'
 
-      # Braket expression wildcard. Except for the beginning
-      # exclamation mark, the whole braket expression can be used
-      # directly as regex but we have to find where the expression
-      # ends.
-      # - "[][!]" matchs ']', '[' and '!'.
-      # - "[]-]" matchs ']' and '-'.
-      # - "[!]a-]" matchs any character except ']', 'a' and '-'.
-      elsif char == '['
-        j = i
-        # Pass brack expression negation.
-        if j < pattern.size && pattern[j].chr == '!'
-          j += 1
-        end
-
-        # Pass first closing braket if it is at the beginning of the
-        # expression.
-        if j < pattern.size && pattern[j].chr == ']'
-          j += 1
-        end
-
-        # Find closing braket. Stop once we reach the end or find it.
-        while j < pattern.size && pattern[j].chr != ']'
-          j += 1
-        end
-
-
-        if j < pattern.size
-          expr = '['
-
-          # Braket expression needs to be negated.
-          if pattern[i].chr == '!'
-            expr += '^'
-            i += 1
-
-          # POSIX declares that the regex braket expression negation
-          # "[^...]" is undefined in a glob pattern. Python's
-          # `fnmatch.translate()` escapes the caret ('^') as a
-          # literal. To maintain consistency with undefined behavior,
-          # I am escaping the '^' as well.
-          elsif pattern[i].chr == '^'
-            expr += '\\^'
-            i += 1
+          # Braket expression wildcard. Except for the beginning
+          # exclamation mark, the whole braket expression can be used
+          # directly as regex but we have to find where the expression
+          # ends.
+          # - "[][!]" matchs ']', '[' and '!'.
+          # - "[]-]" matchs ']' and '-'.
+          # - "[!]a-]" matchs any character except ']', 'a' and '-'.
+        elsif char == '['
+          j = i
+          # Pass brack expression negation.
+          if j < pattern.size && pattern[j].chr == '!'
+            j += 1
           end
 
-          # Escape brackets contained within pattern
-          if pattern[i].chr == ']' && i != j
-            expr += '\]'
-            i += 1
+          # Pass first closing braket if it is at the beginning of the
+          # expression.
+          if j < pattern.size && pattern[j].chr == ']'
+            j += 1
+          end
+
+          # Find closing braket. Stop once we reach the end or find it.
+          while j < pattern.size && pattern[j].chr != ']'
+            j += 1
           end
 
 
-          # Build regex braket expression. Escape slashes so they are
-          # treated as literal slashes by regex as defined by POSIX.
-          expr += pattern[i..j].sub('\\', '\\\\')
+          if j < pattern.size
+            expr = '['
 
-          # Add regex braket expression to regex result.
-          regex += expr
+            # Braket expression needs to be negated.
+            if pattern[i].chr == '!'
+              expr += '^'
+              i += 1
 
-          # Found end of braket expression. Increment j to be one past
-          # the closing braket:
-          #
-          #  [...]
-          #   ^   ^
-          #   i   j
-          #
-          j += 1
-          # Set i to one past the closing braket.
-          i = j
+              # POSIX declares that the regex braket expression negation
+              # "[^...]" is undefined in a glob pattern. Python's
+              # `fnmatch.translate()` escapes the caret ('^') as a
+              # literal. To maintain consistency with undefined behavior,
+              # I am escaping the '^' as well.
+            elsif pattern[i].chr == '^'
+              expr += '\\^'
+              i += 1
+            end
 
-        # Failed to find closing braket, treat opening braket as a
-        # braket literal instead of as an expression.
+            # Escape brackets contained within pattern
+            if pattern[i].chr == ']' && i != j
+              expr += '\]'
+              i += 1
+            end
+
+
+            # Build regex braket expression. Escape slashes so they are
+            # treated as literal slashes by regex as defined by POSIX.
+            expr += pattern[i..j].sub('\\', '\\\\')
+
+            # Add regex braket expression to regex result.
+            regex += expr
+
+            # Found end of braket expression. Increment j to be one past
+            # the closing braket:
+            #
+            #  [...]
+            #   ^   ^
+            #   i   j
+            #
+            j += 1
+            # Set i to one past the closing braket.
+            i = j
+
+            # Failed to find closing braket, treat opening braket as a
+            # braket literal instead of as an expression.
+          else
+            regex += '\['
+          end
+
+          # Regular character, escape it for regex.
         else
-          regex += '\['
+          regex << Regexp.escape(char)
         end
-
-      # Regular character, escape it for regex.
-      else
-        regex << Regexp.escape(char)
       end
+
+      regex
     end
 
-    regex
-  end
-
-  def inclusive?
-    @inclusive
+    def inclusive?
+      @inclusive
+    end
   end
 end

--- a/lib/pathspec/regexspec.rb
+++ b/lib/pathspec/regexspec.rb
@@ -1,17 +1,19 @@
 require 'pathspec/spec'
 
-class RegexSpec < Spec
-  def initialize(regex)
-    @regex = Regexp.compile regex
+class PathSpec
+  class RegexSpec < Spec
+    def initialize(regex)
+      @regex = Regexp.compile regex
 
-    super
-  end
+      super
+    end
 
-  def inclusive?
-    true
-  end
+    def inclusive?
+      true
+    end
 
-  def match(path)
-    @regex.match(path) if @regex
+    def match(path)
+      @regex.match(path) if @regex
+    end
   end
 end

--- a/lib/pathspec/spec.rb
+++ b/lib/pathspec/spec.rb
@@ -1,14 +1,16 @@
-class Spec
-  attr_reader :regex
+class PathSpec
+  class Spec
+    attr_reader :regex
 
-  def initialize(*_)
-  end
+    def initialize(*_)
+    end
 
-  def match(files)
-    raise "Unimplemented"
-  end
+    def match(files)
+      raise "Unimplemented"
+    end
 
-  def inclusive?
-    true
+    def inclusive?
+      true
+    end
   end
 end

--- a/spec/unit/pathspec/gitignorespec_spec.rb
+++ b/spec/unit/pathspec/gitignorespec_spec.rb
@@ -1,20 +1,20 @@
 require 'spec_helper'
 require 'pathspec/gitignorespec'
 
-describe GitIgnoreSpec do
+describe PathSpec::GitIgnoreSpec do
   # Original specification by http://git-scm.com/docs/gitignore
 
   # A blank line matches no files, so it can serve as a separator for
   # readability.
   describe 'does nothing for newlines' do
-    subject { GitIgnoreSpec.new "\n" }
+    subject { PathSpec::GitIgnoreSpec.new "\n" }
     it { is_expected.to_not match('foo.tmp') }
     it { is_expected.to_not match(' ') }
     it { is_expected.to_not be_inclusive }
   end
 
   describe 'does nothing for blank strings' do
-    subject { GitIgnoreSpec.new '' }
+    subject { PathSpec::GitIgnoreSpec.new '' }
     it { is_expected.to_not match 'foo.tmp' }
     it { is_expected.to_not match ' ' }
     it { is_expected.to_not be_inclusive }
@@ -23,21 +23,21 @@ describe GitIgnoreSpec do
   # A line starting with # serves as a comment. Put a backslash ("\") in front
   # of the first hash for patterns that begin with a hash.
   describe 'does nothing for comments' do
-    subject { GitIgnoreSpec.new '# this is a gitignore style comment' }
+    subject { PathSpec::GitIgnoreSpec.new '# this is a gitignore style comment' }
     it { is_expected.to_not match('foo.tmp') }
     it { is_expected.to_not match(' ') }
     it { is_expected.to_not be_inclusive }
   end
 
   describe 'ignores comment char with a slash' do
-    subject { GitIgnoreSpec.new '\#averystrangefile' }
+    subject { PathSpec::GitIgnoreSpec.new '\#averystrangefile' }
     it { is_expected.to match('#averystrangefile') }
     it { is_expected.to_not match('foobar') }
     it { is_expected.to be_inclusive }
   end
 
   describe 'escapes characters with slashes' do
-    subject { GitIgnoreSpec.new 'twinkletwinkle\*' }
+    subject { PathSpec::GitIgnoreSpec.new 'twinkletwinkle\*' }
     it { is_expected.to match('twinkletwinkle*') }
     it { is_expected.to_not match('twinkletwinkletwinkle') }
     it { is_expected.to be_inclusive }
@@ -45,7 +45,7 @@ describe GitIgnoreSpec do
 
   # Trailing spaces are ignored unless they are quoted with backlash ("\").
   describe 'ignores trailing spaces' do
-    subject { GitIgnoreSpec.new 'foo        ' }
+    subject { PathSpec::GitIgnoreSpec.new 'foo        ' }
     it { is_expected.to match('foo') }
     it { is_expected.to_not match('foo        ') }
     it { is_expected.to be_inclusive }
@@ -62,7 +62,7 @@ describe GitIgnoreSpec do
   # backslash ("\") in front of the first "!" for patterns that begin with a
   # literal "!", for example, "\!important!.txt".
   describe 'is exclusive of !' do
-    subject { GitIgnoreSpec.new '!important.txt' }
+    subject { PathSpec::GitIgnoreSpec.new '!important.txt' }
     it { is_expected.to match('important.txt') }
     it { is_expected.to_not be_inclusive }
     it { is_expected.to_not match('!important.txt') }
@@ -74,7 +74,7 @@ describe GitIgnoreSpec do
   # will not match a regular file or a symbolic link foo (this is consistent
   # with the way how pathspec works in general in Git).
   describe 'trailing slashes match directories and their contents but not regular files or symlinks' do
-    subject { GitIgnoreSpec.new 'foo/' }
+    subject { PathSpec::GitIgnoreSpec.new 'foo/' }
     it { is_expected.to match('foo/') }
     it { is_expected.to match('foo/bar') }
     it { is_expected.to match('baz/foo/bar') }
@@ -87,7 +87,7 @@ describe GitIgnoreSpec do
   # of the .gitignore file (relative to the toplevel of the work tree if not
   # from a .gitignore file).
   describe 'handles basic globbing' do
-    subject { GitIgnoreSpec.new '*.tmp' }
+    subject { PathSpec::GitIgnoreSpec.new '*.tmp' }
     it { is_expected.to match('foo.tmp') }
     it { is_expected.to match('foo/bar.tmp') }
     it { is_expected.to match('foo/bar.tmp/baz') }
@@ -96,7 +96,7 @@ describe GitIgnoreSpec do
   end
 
   describe 'handles inner globs' do
-    subject { GitIgnoreSpec.new 'foo-*-bar' }
+    subject { PathSpec::GitIgnoreSpec.new 'foo-*-bar' }
     it { is_expected.to match('foo--bar') }
     it { is_expected.to match('foo-hello-bar') }
     it { is_expected.to match('a/foo-hello-bar') }
@@ -106,7 +106,7 @@ describe GitIgnoreSpec do
   end
 
   describe 'handles postfix globs' do
-    subject { GitIgnoreSpec.new '~temp-*' }
+    subject { PathSpec::GitIgnoreSpec.new '~temp-*' }
     it { is_expected.to match('~temp-') }
     it { is_expected.to match('~temp-foo') }
     it { is_expected.to match('foo/~temp-bar') }
@@ -115,14 +115,14 @@ describe GitIgnoreSpec do
   end
 
   describe 'handles multiple globs' do
-    subject { GitIgnoreSpec.new '*.middle.*' }
+    subject { PathSpec::GitIgnoreSpec.new '*.middle.*' }
     it { is_expected.to match('hello.middle.rb') }
     it { is_expected.to_not match('foo.rb') }
     it { is_expected.to be_inclusive }
   end
 
   describe 'handles dir globs' do
-    subject { GitIgnoreSpec.new 'dir/*' }
+    subject { PathSpec::GitIgnoreSpec.new 'dir/*' }
     it { is_expected.to match('dir/foo') }
     it { is_expected.to_not match('foo/') }
     it { is_expected.to be_inclusive }
@@ -134,14 +134,14 @@ describe GitIgnoreSpec do
   # "Documentation/git.html" but not "Documentation/ppc/ppc.html" or
   # "tools/perf/Documentation/perf.html".
   describe 'handles dir globs' do
-    subject { GitIgnoreSpec.new 'dir/*' }
+    subject { PathSpec::GitIgnoreSpec.new 'dir/*' }
     it { is_expected.to match('dir/foo') }
     it { is_expected.to_not match('foo/') }
     it { is_expected.to be_inclusive }
   end
 
   describe 'handles globs inside of dirs' do
-    subject { GitIgnoreSpec.new 'Documentation/*.html' }
+    subject { PathSpec::GitIgnoreSpec.new 'Documentation/*.html' }
     it { is_expected.to match('Documentation/git.html') }
     it { is_expected.to_not match('Documentation/ppc/ppc.html') }
     it { is_expected.to_not match('tools/perf/Documentation/perf.html') } # TODO: Or is it? Git 2 weirdness?
@@ -149,14 +149,14 @@ describe GitIgnoreSpec do
   end
 
   describe 'handles wildcards' do
-    subject { GitIgnoreSpec.new 'jokeris????' }
+    subject { PathSpec::GitIgnoreSpec.new 'jokeris????' }
     it { is_expected.to match('jokeriswild') }
     it { is_expected.to_not match('jokerisfat') }
     it { is_expected.to be_inclusive }
   end
 
   describe 'handles brackets' do
-    subject { GitIgnoreSpec.new '*[eu][xl]*' }
+    subject { PathSpec::GitIgnoreSpec.new '*[eu][xl]*' }
     it { is_expected.to match('youknowregex') }
     it { is_expected.to match('youknowregularexpressions') }
     it { is_expected.to_not match('youknownothing') }
@@ -164,19 +164,19 @@ describe GitIgnoreSpec do
   end
 
   describe 'handles unmatched brackets' do
-    subject { GitIgnoreSpec.new '*[*[*' }
+    subject { PathSpec::GitIgnoreSpec.new '*[*[*' }
     it { is_expected.to match('bracket[oh[wow') }
     it { is_expected.to be_inclusive }
   end
 
   describe 'handles brackets with carats' do
-    subject { GitIgnoreSpec.new '*[^]' }
+    subject { PathSpec::GitIgnoreSpec.new '*[^]' }
     it { is_expected.to match('myfavorite^') }
     it { is_expected.to be_inclusive }
   end
 
   describe 'handles brackets for brackets' do
-    subject { GitIgnoreSpec.new '*[]]' }
+    subject { PathSpec::GitIgnoreSpec.new '*[]]' }
     it { is_expected.to match('yodawg[]]') }
     it { is_expected.to be_inclusive }
   end
@@ -189,7 +189,7 @@ describe GitIgnoreSpec do
   end
 
   describe 'handles negated brackets' do
-    subject { GitIgnoreSpec.new 'ab[!cd]ef' }
+    subject { PathSpec::GitIgnoreSpec.new 'ab[!cd]ef' }
     it { is_expected.to_not match('abcef') }
     it { is_expected.to match('abzef') }
     it { is_expected.to be_inclusive }
@@ -198,14 +198,14 @@ describe GitIgnoreSpec do
   # A leading slash matches the beginning of the pathname. For example, "/*.c"
   # matches "cat-file.c" but not "mozilla-sha1/sha1.c".
   describe 'handles leading / as relative to base directory' do
-    subject { GitIgnoreSpec.new '/*.c' }
+    subject { PathSpec::GitIgnoreSpec.new '/*.c' }
     it { is_expected.to match('cat-file.c') }
     it { is_expected.to_not match('mozilla-sha1/sha1.c') }
     it { is_expected.to be_inclusive }
   end
 
   describe 'handles simple single paths' do
-    subject { GitIgnoreSpec.new 'spam' }
+    subject { PathSpec::GitIgnoreSpec.new 'spam' }
     it { is_expected.to match('spam') }
     it { is_expected.to match('spam/') }
     it { is_expected.to match('foo/spam') }
@@ -222,7 +222,7 @@ describe GitIgnoreSpec do
   # pattern "foo". "**/foo/bar" matches file or directory "bar" anywhere that is
   # directly under directory "foo".
   describe 'handles prefixed ** as searching any location' do
-    subject { GitIgnoreSpec.new '**/foo' }
+    subject { PathSpec::GitIgnoreSpec.new '**/foo' }
     it { is_expected.to match('foo') }
     it { is_expected.to match('bar/foo') }
     it { is_expected.to match('baz/bar/foo') }
@@ -231,7 +231,7 @@ describe GitIgnoreSpec do
   end
 
   describe 'handles prefixed ** with a directory as searching a file under a directory in any location' do
-    subject { GitIgnoreSpec.new '**/foo/bar' }
+    subject { PathSpec::GitIgnoreSpec.new '**/foo/bar' }
     it { is_expected.to_not match('foo') }
     it { is_expected.to match('foo/bar') }
     it { is_expected.to match('baz/foo/bar') }
@@ -245,7 +245,7 @@ describe GitIgnoreSpec do
   # all files inside directory "abc", relative to the location of the .gitignore
   # file, with infinite depth.
   describe 'handles leading /** as all files inside a directory' do
-    subject { GitIgnoreSpec.new 'abc/**' }
+    subject { PathSpec::GitIgnoreSpec.new 'abc/**' }
     it { is_expected.to match('abc/') }
     it { is_expected.to match('abc/def') }
     it { is_expected.to_not match('123/abc/def') }
@@ -257,7 +257,7 @@ describe GitIgnoreSpec do
   # more directories. For example, "a/**/b" matches "a/b", "a/x/b", "a/x/y/b"
   # and so on.
   describe 'handles /** in the middle of a path' do
-    subject { GitIgnoreSpec.new 'a/**/b' }
+    subject { PathSpec::GitIgnoreSpec.new 'a/**/b' }
     it { is_expected.to match('a/b') }
     it { is_expected.to match('a/x/b') }
     it { is_expected.to match('a/x/y/b') }
@@ -267,7 +267,7 @@ describe GitIgnoreSpec do
   end
 
   describe 'matches all paths when given **' do
-    subject { GitIgnoreSpec.new '**' }
+    subject { PathSpec::GitIgnoreSpec.new '**' }
 
     it { is_expected.to match('a/b') }
     it { is_expected.to match('a/x/b') }
@@ -278,7 +278,7 @@ describe GitIgnoreSpec do
 
   # Other consecutive asterisks are considered invalid.
   describe 'considers other consecutive asterisks invalid' do
-    subject { GitIgnoreSpec.new 'a/***/b' }
+    subject { PathSpec::GitIgnoreSpec.new 'a/***/b' }
     it { is_expected.to_not match('a/b') }
     it { is_expected.to_not match('a/x/b') }
     it { is_expected.to_not match('a/x/y/b') }
@@ -288,14 +288,14 @@ describe GitIgnoreSpec do
   end
 
   describe 'does not match single absolute paths' do
-    subject { GitIgnoreSpec.new "/" }
+    subject { PathSpec::GitIgnoreSpec.new "/" }
     it { is_expected.to_not match('foo.tmp') }
     it { is_expected.to_not match(' ') }
     it { is_expected.to_not match('a/b') }
   end
 
   describe 'nested paths are relative to the file' do
-    subject { GitIgnoreSpec.new 'foo/spam' }
+    subject { PathSpec::GitIgnoreSpec.new 'foo/spam' }
     it { is_expected.to match('foo/spam') }
     it { is_expected.to match('foo/spam/bar') }
     it { is_expected.to_not match('bar/foo/spam') }

--- a/spec/unit/pathspec/spec_spec.rb
+++ b/spec/unit/pathspec/spec_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 require 'pathspec/spec'
 
-describe Spec do
-  subject { Spec.new }
+describe PathSpec::Spec do
+  subject { PathSpec::Spec.new }
 
   it "does not allow matching" do
     expect { subject.match "anything" }.to raise_error


### PR DESCRIPTION
Hi,

This gem defines multiple top level constants (`Spec`, `RegexSpec`, etc).  These constants (specifically the `Spec` constant) clash with other gems, so I've moved these constants under the top level `PathSpec` .

If you're OK with this change, I can fix the indentation (I left the indentation this way so that the diff is easier to read).

Thanks!