### PR TITLE
Use valid license key in gemspec

### DIFF
--- a/pathspec.gemspec
+++ b/pathspec.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.test_files = s.files.grep(%r{^spec/})
   s.require_paths = ['lib']
   s.homepage = 'https://github.com/highb/pathspec-ruby'
-  s.license = 'Apache'
+  s.license = 'Apache-2.0'
   s.add_development_dependency 'bundler', '~> 1.0'
   s.add_development_dependency 'fakefs', '~> 0.12'
   s.add_development_dependency 'rake', '~> 12.3'


### PR DESCRIPTION
When trying to build the gem locally I got the following warning:

    $ gem build pathspec.gemspec
      WARNING:  license value 'Apache' is invalid.  Use a license identifier from
      http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
      Did you mean 'mpich2'?
      WARNING:  See http://guides.rubygems.org/specification-reference/ for help

The gem built successfully, but using the correct key for Apache-2.0 removes the
warning:

    $ gem build pathspec.gemspec
      Successfully built RubyGem
      Name: pathspec
      Version: 0.2.0
      File: pathspec-0.2.0.gem